### PR TITLE
add `zig build` as makeprg

### DIFF
--- a/ftplugin/zig.vim
+++ b/ftplugin/zig.vim
@@ -11,3 +11,4 @@ set shiftwidth=4
 
 setlocal suffixesadd=.zig
 setlocal commentstring=//\ %s
+setlocal makeprg=zig\ build


### PR DESCRIPTION
Just a thought here, in terms of fleshing out this vim plugin, this might be a good first step.

Good: integrates nicely with vim's native `make` command and populates the quickfix list with errors.

Bad: if there is no build.zig file present, it writes one. This is probably a good default for running the command but it seems like a failure mode from vim. I tried overriding the build file with `--build-file whatever.zig` but that just wrote _that_ file, when I would have expected an error `file not present` or some such. I can always generate a build.zig and then rename it if I really wanted to.